### PR TITLE
fixed warning at FIBDatabase

### DIFF
--- a/FIBDatabase.pas
+++ b/FIBDatabase.pas
@@ -1955,7 +1955,7 @@ var
   SV: PISC_STATUS;
   XMDTRealDBCanal:IMDTRealDBCanal;
 begin
-  // isc_res:=0;
+   isc_res:=0;
   (*
    * Check that the database is *not* active, and that it
    * has a database name


### PR DESCRIPTION
I don't know why that was commented out. This changes nothing but suppress warning about uninitialized variable.