### PR TITLE
fixed dataset sorting when empty fields list passed

### DIFF
--- a/FIBDataSet.pas
+++ b/FIBDataSet.pas
@@ -12318,6 +12318,12 @@ var
  vSortedFields:array of TField;
 
 begin
+  if Length(aFields) = 0 then
+  begin
+    DataSet.FSortFields := null;
+    Exit;
+  end;
+
   DataSet.CheckDatasetOpen(' do local sorting ') ;
   TFIBCustomDataSet(DataSet).ChangeScreenCursor(iCurScreenState);
   Inc(DataSet.vSimpleBookMark);


### PR DESCRIPTION
Calling `Sort` procedure with empty `aFields` array leads to memory corruption (at least on Delphi XE).