### PR TITLE
remove unneeded charset assignment

### DIFF
--- a/FIBQuery.pas
+++ b/FIBQuery.pas
@@ -2054,8 +2054,6 @@ begin
     else
      vValue:=PAnsiString(aValue)^;
    end;
-   if vNeedUTFEncode then
-     FXSQLVAR^.sqlsubtype:=chUnicodeFSS;
    if Length(vValue)>32767 then
     sSQLType:=SQL_BLOB;
     if (sSQLType = SQL_BLOB) then


### PR DESCRIPTION
What I have:
I have a column defined as `varchar(255)`. The default charset of the database is UTF-8.

What I'm trying to do:
Saving the string `i'm a unicode string 😁` should properly persist it to the database.

What happens:
The emoji is replaced.

Why does it happen?
FIBPlus already properly encodes the string. What I think happens is that by setting the `sqlsubtype` the string gets transliterated on the server to the UnicodeFSS Charset (which per https://firebirdsql.org/refdocs/langrefupd25-charsets.html has some problems).
By removing the `sqlsubtype` assignment, I'm able to properly save and retrieve the emoji. 