### PR TITLE
do not assume that the value is a blob type if it is bigger than 32kb

### DIFF
--- a/FIBQuery.pas
+++ b/FIBQuery.pas
@@ -2056,8 +2056,6 @@ begin
    end;
    if vNeedUTFEncode then
      FXSQLVAR^.sqlsubtype:=chUnicodeFSS;
-   if Length(vValue)>32767 then
-    sSQLType:=SQL_BLOB;
     if (sSQLType = SQL_BLOB) then
     begin
       if FStreamValue=nil then


### PR DESCRIPTION
What I have:
I have a column defined as `BLOB SUB_TYPE TEXT`. The default charset of the database is UTF-8.

What I'm trying to do:
Persisting a string thats > 32kb in size.

What happens:
I get an error message `Malformed string`.

Why does it happen?
I think by setting the `sSQLType` to `SQL_BLOB` to string is not properly encoded and thus unable to be saved.
The limit of 32kb seems arbitrary and unnecessary, because we can persist strings of any length.
Removing those lines solves the problem on my end.