### PR TITLE
Fix field list in Delphi < XE6 not updating after CloseOpen

### DIFF
--- a/FIBDataSet.pas
+++ b/FIBDataSet.pas
@@ -1246,7 +1246,7 @@ type
     function Translate(Src, Dest: PAnsiChar; ToOem: Boolean): Integer; override;
     function UpdateStatus: TUpdateStatus; override;
     function IsSequenced: Boolean; override;        // Scroll bar
-    property qDefaultFields:boolean read GetDefaultFields ;
+    property {$IF CompilerVersion >= 27}q{$IFEND}DefaultFields:boolean read GetDefaultFields ; //deprecated since Delphi XE6+
   public
 {$IFDEF CSMonitor}
     procedure SetCSMonitorSupportToQ;

--- a/FIBDataSet.pas
+++ b/FIBDataSet.pas
@@ -1246,7 +1246,7 @@ type
     function Translate(Src, Dest: PAnsiChar; ToOem: Boolean): Integer; override;
     function UpdateStatus: TUpdateStatus; override;
     function IsSequenced: Boolean; override;        // Scroll bar
-    property {$IF CompilerVersion >= 27}q{$IFEND}DefaultFields:boolean read GetDefaultFields ; //deprecated since Delphi XE6+
+    property {$IF CompilerVersion >= 27}qDefaultFields{$ELSE}DefaultFields{$IFEND}:boolean read GetDefaultFields ; //deprecated since Delphi XE6+
   public
 {$IFDEF CSMonitor}
     procedure SetCSMonitorSupportToQ;


### PR DESCRIPTION
Reproduced it in Delphi 7 with fibPlus 7.6 using the TpFIBDataSet component

```pas
procedure testCloseOpen();
begin
  with FibDataSet do
  begin
    Close;
    SQLs.SelectSQL.Text := 'select id, name, age from table';
    CloseOpen;
  end;
end;

procedure testOpen();
begin
  with FibDataSet do
  begin
    Close;
    SQLs.SelectSQL.Text := 'select id, name from table';
    Open;
  end;
end;

procedure main();
begin
  testCloseOpen;
  testOpen; // error: field 'age' not found
end;

```
I guess when 'DefaultFields' got deprecated since Delphi XE6 the propery in FIBDataSet was renamed to remove the reference.
It needs to be restored for old Delphi versions.