### PR TITLE
fixed some old delphi packages - removed UnitSyntaxMemo reference

### DIFF
--- a/Packages/FIBPlusEditors2005.dpk
+++ b/Packages/FIBPlusEditors2005.dpk
@@ -1,7 +1,6 @@
 package FIBPlusEditors2005;
 
 {$R *.res}
-{$R 'UnitSyntaxMemo.dcr'}
 {$ALIGN 8}
 {$ASSERTIONS ON}
 {$BOOLEVAL OFF}
@@ -57,7 +56,6 @@ contains
   EdErrorInfo in '..\Editors\EdErrorInfo.pas' {frmErrors},
   ToCodeEditor in '..\Editors\ToCodeEditor.pas',
   ToCodeEditorIntfs in '..\Editors\ToCodeEditorIntfs.pas',
-  UnitSyntaxMemo in '..\Editors\UnitSyntaxMemo.pas',
   FIBToolsConsts in '..\Editors\FIBToolsConsts.pas',
   FindCmp in '..\Editors\FindCmp.pas',
   IBSQLSyn in '..\Editors\IBSQLSyn.pas',

--- a/Packages/FIBPlusEditors2006.dpk
+++ b/Packages/FIBPlusEditors2006.dpk
@@ -1,7 +1,6 @@
 package FIBPlusEditors2006;
 
 {$R *.res}
-{$R 'UnitSyntaxMemo.dcr'}
 {$ALIGN 8}
 {$ASSERTIONS ON}
 {$BOOLEVAL OFF}
@@ -59,7 +58,6 @@ contains
   EdErrorInfo in '..\Editors\EdErrorInfo.pas' {frmErrors},
   ToCodeEditor in '..\Editors\ToCodeEditor.pas',
   ToCodeEditorIntfs in '..\Editors\ToCodeEditorIntfs.pas',
-  UnitSyntaxMemo in '..\Editors\UnitSyntaxMemo.pas',
   IBSQLSyn in '..\Editors\IBSQLSyn.pas',
   pFIBEditorsConsts in '..\Editors\pFIBEditorsConsts.pas',
   RegistryUtils in '..\Editors\RegistryUtils.pas',

--- a/Packages/FIBPlusEditors2007.dpk
+++ b/Packages/FIBPlusEditors2007.dpk
@@ -1,7 +1,6 @@
 package FIBPlusEditors2007;
 
 {$R *.res}
-{$R 'UnitSyntaxMemo.dcr'}
 {$ALIGN 8}
 {$ASSERTIONS OFF}
 {$BOOLEVAL OFF}
@@ -58,7 +57,6 @@ contains
   EdErrorInfo in '..\Editors\EdErrorInfo.pas' {frmErrors},
   ToCodeEditor in '..\Editors\ToCodeEditor.pas',
   ToCodeEditorIntfs in '..\Editors\ToCodeEditorIntfs.pas',
-  UnitSyntaxMemo in '..\Editors\UnitSyntaxMemo.pas',
   FIBToolsConsts in '..\Editors\FIBToolsConsts.pas',
   FindCmp in '..\Editors\FindCmp.pas',
   IBSQLSyn in '..\Editors\IBSQLSyn.pas',

--- a/Packages/FIBPlusEditors2009.dpk
+++ b/Packages/FIBPlusEditors2009.dpk
@@ -63,7 +63,6 @@ contains
   RegistryUtils in '..\Editors\RegistryUtils.pas',
   RegSynEditAlt in '..\Editors\RegSynEditAlt.pas',
   uFIBScriptForm in '..\Editors\uFIBScriptForm.pas' {frmScript},
-  UnitSyntaxMemo in '..\Editors\UnitSyntaxMemo.pas',
   IBSQLSyn in '..\Editors\IBSQLSyn.pas',
   FindCmp in '..\Editors\FindCmp.pas',
   pFIBPreferences in '..\Editors\pFIBPreferences.pas' {frmFIBPreferences},

--- a/Packages/FIBPlusEditors2009.dproj
+++ b/Packages/FIBPlusEditors2009.dproj
@@ -144,7 +144,6 @@
 			<DCCReference Include="..\Editors\uFIBScriptForm.pas">
 				<Form>frmScript</Form>
 			</DCCReference>
-			<DCCReference Include="..\Editors\UnitSyntaxMemo.pas"/>
 			<DCCReference Include="..\Editors\IBSQLSyn.pas"/>
 			<DCCReference Include="..\Editors\FindCmp.pas"/>
 			<DCCReference Include="..\Editors\pFIBPreferences.pas">

--- a/Packages/FIBPlusEditors2010.dpk
+++ b/Packages/FIBPlusEditors2010.dpk
@@ -61,7 +61,6 @@ contains
   RegistryUtils in '..\Editors\RegistryUtils.pas',
   RegSynEditAlt in '..\Editors\RegSynEditAlt.pas',
   uFIBScriptForm in '..\Editors\uFIBScriptForm.pas' {frmScript},
-  UnitSyntaxMemo in '..\Editors\UnitSyntaxMemo.pas',
   IBSQLSyn in '..\Editors\IBSQLSyn.pas',
   FindCmp in '..\Editors\FindCmp.pas',
   pFIBPreferences in '..\Editors\pFIBPreferences.pas' {frmFIBPreferences},

--- a/Packages/FIBPlusEditors2010.dproj
+++ b/Packages/FIBPlusEditors2010.dproj
@@ -140,7 +140,6 @@
 			<DCCReference Include="..\Editors\uFIBScriptForm.pas">
 				<Form>frmScript</Form>
 			</DCCReference>
-			<DCCReference Include="..\Editors\UnitSyntaxMemo.pas"/>
 			<DCCReference Include="..\Editors\IBSQLSyn.pas"/>
 			<DCCReference Include="..\Editors\FindCmp.pas"/>
 			<DCCReference Include="..\Editors\pFIBPreferences.pas">

--- a/Packages/FIBPlusEditors6.dpk
+++ b/Packages/FIBPlusEditors6.dpk
@@ -1,7 +1,6 @@
 package FIBPlusEditors6;
 
 {$R *.res}
-{$R 'UnitSyntaxMemo.dcr'}
 {$ALIGN 8}
 {$ASSERTIONS ON}
 {$BOOLEVAL OFF}
@@ -60,7 +59,6 @@ contains
   RTTIRoutines in '..\Editors\RTTIRoutines.pas',
   pFIBEditorsConsts in '..\Editors\pFIBEditorsConsts.pas',
   IBSQLSyn in '..\Editors\IBSQLSyn.pas',
-  UnitSyntaxMemo in '..\Editors\UnitSyntaxMemo.pas',
   RegSynEditAlt in '..\Editors\RegSynEditAlt.pas',
   FIBToolsConsts in '..\Editors\FIBToolsConsts.pas',
   FindCmp in '..\Editors\FindCmp.pas',


### PR DESCRIPTION
Some CB packages leaved untouched and still wait for fixes.