### PR TITLE
fixed clearing queries cache

### DIFF
--- a/pFIBCacheQueries.pas
+++ b/pFIBCacheQueries.pas
@@ -332,7 +332,7 @@ end;
 procedure ClearQueryCacheList(DB:TFIBDataBase);
 var
  cq:TCacheQueries;
- i:integer;
+// i:integer;
 begin
  cq:=CacheList.GetCacheForDB(DB);
  if cq<>nil then

--- a/pFIBCacheQueries.pas
+++ b/pFIBCacheQueries.pas
@@ -340,8 +340,9 @@ begin
  begin
    CacheList.FLock.Acquire;
    try
-     for i:=FListUnused.Count-1 downto 0 do
-      TFIBQuery(FListUnused.Objects[i]).Free;
+     FListUnused.FullClear;
+//     for i:=FListUnused.Count-1 downto 0 do
+//      TFIBQuery(FListUnused.Objects[i]).Free;
    finally
      CacheList.FLock.Release
    end;

--- a/pFIBLists.pas
+++ b/pFIBLists.pas
@@ -302,7 +302,7 @@ var i:integer;
 begin
   with  FList do
   begin
-   for i:=0 to Pred(Count)  do
+   for i:=Pred(Count) downto 0 do
    begin
     if (Objects[i] is TComponent) and  (csDestroying in TComponent(Objects[i]).ComponentState) then
       Continue;


### PR DESCRIPTION
When clearing cache list size of the list may stay unchanged. Also fixed TObjStringList.FullClear method.