### PR TITLE
Fix Firebird 3 Boolean datatype to PByte

### DIFF
--- a/FIBQuery.pas
+++ b/FIBQuery.pas
@@ -2570,7 +2570,9 @@ begin
   Result := False;
   if not IsNull then
     case FXSQLVAR^.sqltype and (not 1) of
-      FB3_SQL_BOOLEAN,SQL_BOOLEAN,SQL_SHORT:
+      FB3_SQL_BOOLEAN:
+        Result := PByte(FXSQLVAR^.sqldata)^=ISC_TRUE;
+      SQL_BOOLEAN,SQL_SHORT:
         Result := PShort(FXSQLVAR^.sqldata)^=ISC_TRUE;
       SQL_LONG:
        Result  := PLong(FXSQLVAR^.sqldata)^=ISC_TRUE;


### PR DESCRIPTION
The database is alayws returning `false` by reading the fibquery boolean fields with a firebird 3 / 4 database with `AsBoolean`.

So I search for the reason and the right `sqldata`-type I found the documentation: 
see https://firebirdsql.org/file/community/conference-2014/pdf/02_fb.2014.whatsnew.30.en.pdf page 15

The correct datatype for boolean fields is a `byte`. So I changed the case statement for `FB3_SQL_BOOLEAN` and now it's working.

I hope the PR is allright :)
Best regards!