### PR TITLE
Stop "Transaction not active" error for StoredProc component when database not open

### DIFF
--- a/FIBQuery.pas
+++ b/FIBQuery.pas
@@ -524,7 +524,7 @@ type
     procedure CheckClosed(const OpName:Ansistring);// raise error if query is not closed.
     procedure CheckOpen(const OpName:Ansistring); // raise error if query is not open.
     procedure CheckValidStatement;   // raise error if statement is invalid.
-    procedure Close;               // close the query.
+    procedure Close; virtual;        // close the query.
     function  Current: TFIBXSQLDA;
     procedure ExecQuery; virtual;               // ExecQuery the query.
     procedure ExecuteImmediate;
@@ -535,7 +535,7 @@ type
 {$ENDIF}
     procedure FreeHandle;
     function  Next: TFIBXSQLDA;
-    procedure Prepare;                  // Prepare the query.
+    procedure Prepare; virtual;         // Prepare the query.
 
     function FieldByName(const FieldName: string): TFIBXSQLVAR;
     function FindField(const FieldName: string): TFIBXSQLVAR;

--- a/pFIBStoredProc.pas
+++ b/pFIBStoredProc.pas
@@ -42,6 +42,8 @@ type
   public
     constructor Create(AOwner: TComponent); override;
     destructor Destroy; override;
+    procedure Prepare; override;
+    procedure ExecQuery; override;
     function   GetParamDefValue(ParamNo:integer):string; overload;
     function   GetParamDefValue(const ParamName:string):string; overload;
 
@@ -62,28 +64,13 @@ const
   'ORDER BY PP.RDB$PARAMETER_NUMBER';
 
 procedure TpFIBStoredProc.SetStoredProc(const Value: string);
-var ProcName:string;
 begin
   if (Value <> FStoredProc) then
   begin
    FStoredProc := Value;
    if not (csReading in ComponentState) then
    begin
-//     FBase.CheckDatabase;
-     if Assigned(Database) then
-     if  IsBlank(Value) then
-      SQL.Clear
-     else
-     begin
-      ProcName:=EasyFormatIdentifier(Database.SQLDialect, FStoredProc,
-       Database.EasyFormatsStr
-      );
-      SQL.Text :=
-       ListSPInfo.GetExecProcTxt(Database,
-        ProcName
-        ,csDesigning in ComponentState
-       );
-     end;
+     SQL.Clear;
    end;
   end;
 end;
@@ -205,5 +192,28 @@ begin
   end;
 end;
 
-end.
+procedure TpFIBStoredProc.ExecQuery;
+begin
+  if not Prepared then
+    Prepare;
+  inherited;
+end;
 
+procedure TpFIBStoredProc.Prepare;
+var ProcName:string;
+begin
+  if (SQL.Count = 0) and not IsBlank(FStoredProc) then
+  begin
+    ProcName:=EasyFormatIdentifier(Database.SQLDialect, FStoredProc,
+     Database.EasyFormatsStr
+    );
+    SQL.Text :=
+     ListSPInfo.GetExecProcTxt(Database,
+      ProcName
+      ,csDesigning in ComponentState
+     );
+  end;
+  inherited;
+end;
+
+end.


### PR DESCRIPTION
Setting the procedure name when the database is not connected causes the above exception.

To fix this I moved the code that generates the SQL from where it sets the procedure name to just prior to preparing the statement.
