### PR TITLE
Fix TFIBCustomDataSet.DoFieldValidate getting empty value on date fields

### DIFF
--- a/FIBDataSet.pas
+++ b/FIBDataSet.pas
@@ -11635,7 +11635,10 @@ begin
     FValidatingFieldBuffer:=Buffer;
     FValidatedField:=Field;
     FValidatedRec:= ActiveRecord;
-    Field.Validate(Buffer);
+    if Field is TIntegerField then
+     Field.Validate(Buffer)
+    else
+     Field.OnValidate(Field);
    finally
      Exclude(FRunState,drsInFieldValidate);
      FValidatingFieldBuffer:=nil;


### PR DESCRIPTION
Previous fix #76 broke validation of date fields, entering on their OnValidate event always with Null value.