### PR TITLE
Minor change in DBParsers and better thread safe handle in FIBDatabase

### DIFF
--- a/DBParsers.pas
+++ b/DBParsers.pas
@@ -510,7 +510,7 @@ var
         case iOperator of
           coLISTELEM2:
             begin
-              Result := VarArrayCreate ([0, 50], VarVariant); // Create VarArray for ListElements Values
+              Result := VarArrayCreate ([0, 1000], VarVariant); // Create VarArray for ListElements Values
               pArg1 := pfdStart;
               Inc(pArg1, CANEXPRSIZE + PWord(@pfd[0])^);
 


### PR DESCRIPTION
I did theese changese:
- DBParsers.pas: Increased array dimension in TExpressionParser to avoid errors in parsing complex dataset filters
- FIBDatabase.pas: added 2 critcal sections to allow a better thread safe handle in case of multiple active database connections

I think there is also a mess with CR LF with several sources (also these ones) infact my modified files seems differents in every single row  (I dont' know how to solve the problem)